### PR TITLE
Case sensitivity for deploying to bluemix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-graphapi",
   "version": "0.0.6",
   "description": "Node.js package for making Azure Active Directory Graph API calls.",
-  "main": "graphapi.js",
+  "main": "GraphAPI.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/fhellwig/azure-graphapi"


### PR DESCRIPTION
When deploying as in a meteor application on bluemix using node 0.10.36 the case mismatch between the package.json and GraphAPI.js ment that the package failed to load. This change fixes that issue.